### PR TITLE
chore(ci): optimize AppVeyor configuration for faster builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,17 +9,12 @@ build_script:
 
 shallow_clone: true
 
-# Timeout after 10 minutes to prevent indefinite queuing
-build:
-  timeout: 10
-
 environment:
   nodejs_version: '20'
   NODE_ENV: test
 
 install:
-  - nvm install $nodejs_version
-  - nvm use $nodejs_version
+  - ps: Install-Product node $env:nodejs_version
   - node -v
   - npm -v
   - npm ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 
-# Use Windows image with PowerShell helper `Install-Product`
-image: Visual Studio 2022
+# Use Ubuntu for faster build allocation on free tier
+image: Ubuntu2204
 
 # Switch to script mode (overrides default MSBuild)
 build_script:
@@ -9,21 +9,23 @@ build_script:
 
 shallow_clone: true
 
+# Timeout after 10 minutes to prevent indefinite queuing
+build:
+  timeout: 10
+
 environment:
   nodejs_version: '20'
   NODE_ENV: test
 
-init:
-  - ps: Write-Host "Using Node.js $env:nodejs_version on $env:APPVEYOR_BUILD_WORKER_IMAGE"
-
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - nvm install $nodejs_version
+  - nvm use $nodejs_version
   - node -v
   - npm -v
   - npm ci
 
 artifacts:
-  - path: coverage\lcov.info
+  - path: coverage/lcov.info
     name: coverage-lcov
 
 cache:


### PR DESCRIPTION
## Summary
Optimize AppVeyor CI configuration to resolve perpetual "queued" status by switching to a faster build environment.

## Changes
- **Image**: Visual Studio 2022 → Ubuntu2204 (faster allocation on free tier)
- **Timeout**: Added 10-minute build timeout to prevent indefinite queuing
- **Install**: PowerShell Install-Product → nvm (Ubuntu-compatible)
- **Artifacts**: Windows path (`coverage\lcov.info`) → Linux path (`coverage/lcov.info`)

## Why Ubuntu?
Ubuntu images allocate much faster than Windows/Visual Studio images on AppVeyor's free tier, which should resolve the build queue bottleneck.

## Testing
- Pre-push hooks passed (lint, format, build, unit tests)
- Will verify AppVeyor build starts promptly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)