### PR TITLE
chore(settings): add auto-allow permissions for common operations

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,9 @@
       "Bash(npx husky:*)",
       "Bash(chmod:*)",
       "Bash(npm run *)",
-      "Bash(npm audit *)"
+      "Bash(npm audit *)",
+      "Bash(git restore *)",
+      "Bash(npm install *)"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Summary
Add auto-allow permissions for frequently used development operations to reduce friction.

## Changes
Added to `.claude/settings.local.json`:
- `Bash(git restore *)` - File restoration operations
- `Bash(npm install *)` - Package installation operations

## Why
These commands are frequently used during development and pose minimal risk. Auto-allowing them streamlines the development workflow.

## Testing
- Pre-push hooks passed (lint, format, build, unit tests)
- Settings syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)