### PR TITLE
ci: add explicit CodeQL workflow configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: 'CodeQL Advanced'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Run at 2:30 AM UTC every Monday
+    - cron: '30 2 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      # Required for all workflows
+      security-events: write
+      # Required to fetch internal or private CodeQL packs
+      packages: read
+      # Only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          # GitHub Actions workflows (YAML)
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Specify CodeQL query suites
+          queries: +security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'
+          # Upload results even if there are no findings
+          upload: always


### PR DESCRIPTION
## Summary

Adds a dedicated CodeQL Advanced Security workflow to ensure consistent code scanning across all PRs and branches.

## Problem

GitHub Code Scanning shows warnings on PRs:
```
⚠️ Code scanning cannot determine the alerts introduced by this pull request, 
because 2 configurations present on refs/heads/master were not found:
- /language:actions
- /language:javascript-typescript
```

This occurs when GitHub's default setup cannot establish a consistent baseline for comparison between the PR and master branch.

## Solution

This PR adds an explicit CodeQL workflow (`.github/workflows/codeql.yml`) that:

✅ Scans **JavaScript/TypeScript** code  
✅ Scans **GitHub Actions workflows** (YAML)  
✅ Runs **security-and-quality** query suites  
✅ Scheduled weekly scans (Mondays at 2:30 AM UTC)  
✅ Explicit category labeling (`/language:actions`, `/language:javascript-typescript`)  
✅ Always uploads results for better diff tracking  

## Benefits

- **Eliminates "configuration not found" warnings** on future PRs
- **Consistent baseline** for security alert comparisons
- **Complements** GitHub's default CodeQL setup
- **Weekly scheduled scans** catch issues between PRs
- **Better security coverage** with security-and-quality queries

## Testing

- ✅ CI checks pass (lint, format, build, tests)
- ✅ Workflow syntax validated by GitHub Actions
- CodeQL will run automatically when this PR is merged

## References

- [GitHub CodeQL Documentation](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql)
- [CodeQL Action](https://github.com/github/codeql-action)